### PR TITLE
Datetime serialized quote removal

### DIFF
--- a/src/Nano.Demo.Mvc4/www/ApiExplorer/index.html
+++ b/src/Nano.Demo.Mvc4/www/ApiExplorer/index.html
@@ -499,6 +499,7 @@ body{font-family:"Helvetica Neue",Helvetica,Arial,sans-serif;font-size:14px;line
                 '        {',
                 '           if ( obj is string ) return obj.ToString();',
                 '           if ( obj == null ) return null;',
+                '           if (obj is DateTime) return Newtonsoft.Json.JsonConvert.SerializeObject(obj).Replace("\\"", "");',
                 '           return Newtonsoft.Json.JsonConvert.SerializeObject( obj );',
                 '        };',
                 '',

--- a/src/Nano.Demo.SelfHost/www/ApiExplorer/index.html
+++ b/src/Nano.Demo.SelfHost/www/ApiExplorer/index.html
@@ -499,6 +499,7 @@ body{font-family:"Helvetica Neue",Helvetica,Arial,sans-serif;font-size:14px;line
                 '        {',
                 '           if ( obj is string ) return obj.ToString();',
                 '           if ( obj == null ) return null;',
+                '           if (obj is DateTime) return Newtonsoft.Json.JsonConvert.SerializeObject(obj).Replace("\\"", "");',
                 '           return Newtonsoft.Json.JsonConvert.SerializeObject( obj );',
                 '        };',
                 '',

--- a/src/Nano.Demo.TopshelfSelfHost/www/ApiExplorer/index.html
+++ b/src/Nano.Demo.TopshelfSelfHost/www/ApiExplorer/index.html
@@ -499,6 +499,7 @@ body{font-family:"Helvetica Neue",Helvetica,Arial,sans-serif;font-size:14px;line
                 '        {',
                 '           if ( obj is string ) return obj.ToString();',
                 '           if ( obj == null ) return null;',
+                '           if (obj is DateTime) return Newtonsoft.Json.JsonConvert.SerializeObject(obj).Replace("\\"", "");',
                 '           return Newtonsoft.Json.JsonConvert.SerializeObject( obj );',
                 '        };',
                 '',

--- a/src/Nano.Tests/www/ApiExplorer/index.html
+++ b/src/Nano.Tests/www/ApiExplorer/index.html
@@ -499,6 +499,7 @@ body{font-family:"Helvetica Neue",Helvetica,Arial,sans-serif;font-size:14px;line
                 '        {',
                 '           if ( obj is string ) return obj.ToString();',
                 '           if ( obj == null ) return null;',
+                '           if (obj is DateTime) return Newtonsoft.Json.JsonConvert.SerializeObject(obj).Replace("\\"", "");',
                 '           return Newtonsoft.Json.JsonConvert.SerializeObject( obj );',
                 '        };',
                 '',


### PR DESCRIPTION
The proxy generator serializes a C# Datetime into a json string and then adds another, extra set of quotes before sending request so this change removes the extra set of quotes.