### PR TITLE
Add check for invalid path characters and fix formatting.

### DIFF
--- a/src/Nano.Tests/RequestHandlers/DirectoryRequestHandlerShould.cs
+++ b/src/Nano.Tests/RequestHandlers/DirectoryRequestHandlerShould.cs
@@ -66,6 +66,27 @@ namespace Nano.Tests.RequestHandlers
             }
         }
 
+        [TestCase( "/*/" )]
+        [TestCase( "/Random/Path<" )]
+        public void Return_An_Http_404_When_The_Requested_Path_Contains_Invalid_Chars_And_The_returnHttp404WhenFileWasNotFound_Parameter_Was_Set_To_True( string path )
+        {
+            using ( var server = NanoTestServer.Start() )
+            {
+                // Arrange
+                server.NanoConfiguration.AddDirectory( "/", "www", returnHttp404WhenFileWasNotFound: true );
+
+                // Act
+                using ( var response = HttpHelper.GetHttpWebResponse( server.GetUrl() + path ) )
+                {
+                    // Visual Assertion
+                    Trace.WriteLine( response.GetResponseString() );
+
+                    // Assert
+                    Assert.That( response.StatusCode == HttpStatusCode.NotFound );
+                }
+            }
+        }
+
         [Test]
         public void Return_An_Http_200_When_The_Requested_Path_Does_Not_Exist_And_The_returnHttp404WhenFileWasNotFound_Parameter_Was_Set_To_False()
         {

--- a/src/Nano/Nano.cs
+++ b/src/Nano/Nano.cs
@@ -2756,39 +2756,39 @@ namespace Nano.Web.Core
                 string encodedPartialRequestPath = partialRequestPath.Replace( "/", Constants.DirectorySeparatorString ).TrimStart( Constants.DirectorySeparatorChar );
                 string fullFileSystemPath = Path.Combine( nanoContext.RootFolderPath, FileSystemPath, encodedPartialRequestPath );
 
-				if ( IsCaseSensitiveFileSystem ) fullFileSystemPath = GetPathCaseSensitive( fullFileSystemPath );
+                if ( IsCaseSensitiveFileSystem ) fullFileSystemPath = GetPathCaseSensitive( fullFileSystemPath );
 
-				if ( !String.IsNullOrWhiteSpace( fullFileSystemPath ) )
-				{					
-					if ( nanoContext.TryReturnFile( new FileInfo( fullFileSystemPath ) ) ) return nanoContext;
-                
-					var directoryInfo = new DirectoryInfo( fullFileSystemPath );			
+                if ( !string.IsNullOrWhiteSpace( fullFileSystemPath ) && fullFileSystemPath.IndexOfAny( Path.GetInvalidPathChars() ) < 0 )
+                {
+                    if ( nanoContext.TryReturnFile( new FileInfo( fullFileSystemPath ) ) ) return nanoContext;
 
-					if ( directoryInfo.Exists )
-					{
-						// If the URL does not end with a forward slash then redirect to the same URL with a forward slash
-						// so that relative URLs will work correctly
-						if ( nanoContext.Request.Url.Path.EndsWith( "/", StringComparison.Ordinal ) == false )
-						{
-							string url = nanoContext.Request.Url.BasePath + nanoContext.Request.Url.Path + "/" + nanoContext.Request.Url.Query;
-							nanoContext.Response.Redirect( url );
-							return nanoContext;
-						}
+                    var directoryInfo = new DirectoryInfo( fullFileSystemPath );
 
-						foreach ( string defaultDocument in DefaultDocuments )
-						{
-							string path = Path.Combine( fullFileSystemPath, defaultDocument );
+                    if ( directoryInfo.Exists )
+                    {
+                        // If the URL does not end with a forward slash then redirect to the same URL with a forward slash
+                        // so that relative URLs will work correctly
+                        if ( nanoContext.Request.Url.Path.EndsWith( "/", StringComparison.Ordinal ) == false )
+                        {
+                            string url = nanoContext.Request.Url.BasePath + nanoContext.Request.Url.Path + "/" + nanoContext.Request.Url.Query;
+                            nanoContext.Response.Redirect( url );
+                            return nanoContext;
+                        }
 
-							if ( IsCaseSensitiveFileSystem )
-								path = GetPathCaseSensitive( path );
+                        foreach ( string defaultDocument in DefaultDocuments )
+                        {
+                            string path = Path.Combine( fullFileSystemPath, defaultDocument );
 
-							if ( nanoContext.TryReturnFile( new FileInfo( path ) ) )
-								return nanoContext;
-						}
-					}
-				}
+                            if ( IsCaseSensitiveFileSystem )
+                                path = GetPathCaseSensitive( path );
 
-                if( ReturnHttp404WhenFileWasNoFound ) return nanoContext.ReturnHttp404NotFound();
+                            if ( nanoContext.TryReturnFile( new FileInfo( path ) ) )
+                                return nanoContext;
+                        }
+                    }
+                }
+
+                if ( ReturnHttp404WhenFileWasNoFound ) return nanoContext.ReturnHttp404NotFound();
 
                 return nanoContext;
             }

--- a/src/Nano/Nano.cs
+++ b/src/Nano/Nano.cs
@@ -2758,7 +2758,7 @@ namespace Nano.Web.Core
 
                 if ( IsCaseSensitiveFileSystem ) fullFileSystemPath = GetPathCaseSensitive( fullFileSystemPath );
 
-                if ( !string.IsNullOrWhiteSpace( fullFileSystemPath ) && fullFileSystemPath.IndexOfAny( Path.GetInvalidPathChars() ) < 0 )
+                if ( !string.IsNullOrWhiteSpace( fullFileSystemPath ) && fullFileSystemPath.IndexOfAny( Path.GetInvalidFileNameChars() ) < 0 )
                 {
                     if ( nanoContext.TryReturnFile( new FileInfo( fullFileSystemPath ) ) ) return nanoContext;
 


### PR DESCRIPTION
Found this issue while debugging an issue for one of the teams. Illegal characters in the path throw an exception in the ctor of FileInfo. This adds a check before that (but after file path transformations) to bypass the file operations if the path contains illegal characters. Also fixed a spacing / formatting issue with that method.