### PR TITLE
Update ApiExplorer proxy from generating duplicate classes

### DIFF
--- a/src/Nano.Demo.AspNet/www/ApiExplorer/index.html
+++ b/src/Nano.Demo.AspNet/www/ApiExplorer/index.html
@@ -1102,7 +1102,10 @@ body{font-family:"Helvetica Neue",Helvetica,Arial,sans-serif;font-size:14px;line
 
             classTemplate = replaceAllOccurrences(classTemplate, "{{ClassName}}", model.Type);
             classTemplate = replaceAllOccurrences(classTemplate, "{{PropertyList}}", properties);
-            nestedClassList += classTemplate + "\n";
+
+            if (nestedClassList.indexOf(classTemplate) <= 0) {
+                nestedClassList += classTemplate + "\n";
+            }
         }
 
         nestedClassList = nestedClassList === "" ? nestedClassList : nestedClassList.slice(0, -2); // Remove trailing line break

--- a/src/Nano.Demo.SelfHost.Console/www/ApiExplorer/index.html
+++ b/src/Nano.Demo.SelfHost.Console/www/ApiExplorer/index.html
@@ -1102,7 +1102,10 @@ body{font-family:"Helvetica Neue",Helvetica,Arial,sans-serif;font-size:14px;line
 
             classTemplate = replaceAllOccurrences(classTemplate, "{{ClassName}}", model.Type);
             classTemplate = replaceAllOccurrences(classTemplate, "{{PropertyList}}", properties);
-            nestedClassList += classTemplate + "\n";
+
+            if (nestedClassList.indexOf(classTemplate) <= 0) {
+                nestedClassList += classTemplate + "\n";
+            }
         }
 
         nestedClassList = nestedClassList === "" ? nestedClassList : nestedClassList.slice(0, -2); // Remove trailing line break

--- a/src/Nano.Demo.SelfHost.WindowsService/www/ApiExplorer/index.html
+++ b/src/Nano.Demo.SelfHost.WindowsService/www/ApiExplorer/index.html
@@ -1102,7 +1102,10 @@ body{font-family:"Helvetica Neue",Helvetica,Arial,sans-serif;font-size:14px;line
 
             classTemplate = replaceAllOccurrences(classTemplate, "{{ClassName}}", model.Type);
             classTemplate = replaceAllOccurrences(classTemplate, "{{PropertyList}}", properties);
-            nestedClassList += classTemplate + "\n";
+
+            if (nestedClassList.indexOf(classTemplate) <= 0) {
+                nestedClassList += classTemplate + "\n";
+            }
         }
 
         nestedClassList = nestedClassList === "" ? nestedClassList : nestedClassList.slice(0, -2); // Remove trailing line break

--- a/src/Nano.Tests/www/ApiExplorer/index.html
+++ b/src/Nano.Tests/www/ApiExplorer/index.html
@@ -1102,7 +1102,10 @@ body{font-family:"Helvetica Neue",Helvetica,Arial,sans-serif;font-size:14px;line
 
             classTemplate = replaceAllOccurrences(classTemplate, "{{ClassName}}", model.Type);
             classTemplate = replaceAllOccurrences(classTemplate, "{{PropertyList}}", properties);
-            nestedClassList += classTemplate + "\n";
+            
+            if (nestedClassList.indexOf(classTemplate) <= 0) {
+                nestedClassList += classTemplate + "\n";
+            }
         }
 
         nestedClassList = nestedClassList === "" ? nestedClassList : nestedClassList.slice(0, -2); // Remove trailing line break


### PR DESCRIPTION
Simple change that prevents the ApiExplore Index page from generating duplicate classes when creating proxies.