### PR TITLE
Adding parameter defaults to generated C# proxy

### DIFF
--- a/src/Nano.Demo.AspNet/www/ApiExplorer/index.html
+++ b/src/Nano.Demo.AspNet/www/ApiExplorer/index.html
@@ -1052,7 +1052,12 @@ body{font-family:"Helvetica Neue",Helvetica,Arial,sans-serif;font-size:14px;line
 
                     for (var j = 0; j < operation.InputParameters.length; j++) {
                         var inputParameter = operation.InputParameters[j];
-                        inputParameterList += inputParameter.Type + " " + inputParameter.Name + ", ";
+                        inputParameterList += inputParameter.Type + " " + inputParameter.Name;
+                        if (inputParameter.HasDefaultValue) {
+                            var defaultValue = ((inputParameter.Type === "String") && (inputParameter.DefaultValue !== null)) ? ('"' + inputParameter.DefaultValue + '"') : inputParameter.DefaultValue;
+                            inputParameterList += (" = " + defaultValue);
+                        }
+                        inputParameterList += ", ";
                         parameterNameList += inputParameter.Name + ", ";
                         nameValueCollectionParameterList += '{"' + inputParameter.Name + '", Configuration.Serialize(' + inputParameter.Name + ')}, ';
 

--- a/src/Nano.Demo.AspNet/www/ApiExplorer/index.html
+++ b/src/Nano.Demo.AspNet/www/ApiExplorer/index.html
@@ -889,7 +889,7 @@ body{font-family:"Helvetica Neue",Helvetica,Arial,sans-serif;font-size:14px;line
             '        /// <summary>Serializes the given object to a string.</summary>',
             '        public static Func<object, string> Serialize = obj =>',
             '        {',
-            '           if ( obj is string ) return obj.ToString();',
+            '           if ((obj is string) || (obj is Guid)) return obj.ToString();',
             '           if ( obj == null ) return null;',
             '           if (obj is DateTime) return Newtonsoft.Json.JsonConvert.SerializeObject(obj).Replace("\\"", "");',
             '           return Newtonsoft.Json.JsonConvert.SerializeObject( obj );',

--- a/src/Nano.Demo.SelfHost.Console/www/ApiExplorer/index.html
+++ b/src/Nano.Demo.SelfHost.Console/www/ApiExplorer/index.html
@@ -1052,7 +1052,12 @@ body{font-family:"Helvetica Neue",Helvetica,Arial,sans-serif;font-size:14px;line
 
                     for (var j = 0; j < operation.InputParameters.length; j++) {
                         var inputParameter = operation.InputParameters[j];
-                        inputParameterList += inputParameter.Type + " " + inputParameter.Name + ", ";
+                        inputParameterList += inputParameter.Type + " " + inputParameter.Name;
+                        if (inputParameter.HasDefaultValue) {
+                            var defaultValue = ((inputParameter.Type === "String") && (inputParameter.DefaultValue !== null)) ? ('"' + inputParameter.DefaultValue + '"') : inputParameter.DefaultValue;
+                            inputParameterList += (" = " + defaultValue);
+                        }
+                        inputParameterList += ", ";
                         parameterNameList += inputParameter.Name + ", ";
                         nameValueCollectionParameterList += '{"' + inputParameter.Name + '", Configuration.Serialize(' + inputParameter.Name + ')}, ';
 

--- a/src/Nano.Demo.SelfHost.Console/www/ApiExplorer/index.html
+++ b/src/Nano.Demo.SelfHost.Console/www/ApiExplorer/index.html
@@ -627,10 +627,6 @@ body{font-family:"Helvetica Neue",Helvetica,Arial,sans-serif;font-size:14px;line
         return getId(rowData) + 'SubmitButton';
     };
 
-    function getRawModeButtonId(rowData) {
-        return getId(rowData) + 'RawModeButton';
-    };
-
     function getClearButtonId(rowData) {
         return getId(rowData) + 'ClearButton';
     };
@@ -724,10 +720,6 @@ body{font-family:"Helvetica Neue",Helvetica,Arial,sans-serif;font-size:14px;line
             clearSuccessAndFailureResults(rowData);
             var resultsId = getResultsId(rowData);
             $('#' + resultsId).hide();
-        });
-
-        $('.btn-rawMode').click(function () {
-            $(formInputs).toggle();
         });
 
         $(".inputParameter").on("keydown", function (e) {
@@ -853,7 +845,6 @@ body{font-family:"Helvetica Neue",Helvetica,Arial,sans-serif;font-size:14px;line
             '           <tbody></tbody>',
             '       </table>',
             '       <div style="padding-left:50px; margin-top:10px;">',
-            '           <button type="button" id="{{RawModeButtonId}}" class="btn btn-rawMode">Use Raw Mode</button>',
             '           <button type="submit" id="{{SubmitButtonId}}" class="btn btn-submit">Submit</button>',
             '           &nbsp;&nbsp;',
             '           <button type="button" id="{{ClearButtonId}}" class="btn btn-clear">Clear</button>',

--- a/src/Nano.Demo.SelfHost.Console/www/ApiExplorer/index.html
+++ b/src/Nano.Demo.SelfHost.Console/www/ApiExplorer/index.html
@@ -627,6 +627,10 @@ body{font-family:"Helvetica Neue",Helvetica,Arial,sans-serif;font-size:14px;line
         return getId(rowData) + 'SubmitButton';
     };
 
+    function getRawModeButtonId(rowData) {
+        return getId(rowData) + 'RawModeButton';
+    };
+
     function getClearButtonId(rowData) {
         return getId(rowData) + 'ClearButton';
     };
@@ -720,6 +724,10 @@ body{font-family:"Helvetica Neue",Helvetica,Arial,sans-serif;font-size:14px;line
             clearSuccessAndFailureResults(rowData);
             var resultsId = getResultsId(rowData);
             $('#' + resultsId).hide();
+        });
+
+        $('.btn-rawMode').click(function () {
+            $(formInputs).toggle();
         });
 
         $(".inputParameter").on("keydown", function (e) {
@@ -845,6 +853,7 @@ body{font-family:"Helvetica Neue",Helvetica,Arial,sans-serif;font-size:14px;line
             '           <tbody></tbody>',
             '       </table>',
             '       <div style="padding-left:50px; margin-top:10px;">',
+            '           <button type="button" id="{{RawModeButtonId}}" class="btn btn-rawMode">Use Raw Mode</button>',
             '           <button type="submit" id="{{SubmitButtonId}}" class="btn btn-submit">Submit</button>',
             '           &nbsp;&nbsp;',
             '           <button type="button" id="{{ClearButtonId}}" class="btn btn-clear">Clear</button>',
@@ -889,7 +898,7 @@ body{font-family:"Helvetica Neue",Helvetica,Arial,sans-serif;font-size:14px;line
             '        /// <summary>Serializes the given object to a string.</summary>',
             '        public static Func<object, string> Serialize = obj =>',
             '        {',
-            '           if ( obj is string ) return obj.ToString();',
+            '           if ((obj is string) || (obj is Guid)) return obj.ToString();',
             '           if ( obj == null ) return null;',
             '           if (obj is DateTime) return Newtonsoft.Json.JsonConvert.SerializeObject(obj).Replace("\\"", "");',
             '           return Newtonsoft.Json.JsonConvert.SerializeObject( obj );',

--- a/src/Nano.Demo.SelfHost.WindowsService/www/ApiExplorer/index.html
+++ b/src/Nano.Demo.SelfHost.WindowsService/www/ApiExplorer/index.html
@@ -1052,7 +1052,12 @@ body{font-family:"Helvetica Neue",Helvetica,Arial,sans-serif;font-size:14px;line
 
                     for (var j = 0; j < operation.InputParameters.length; j++) {
                         var inputParameter = operation.InputParameters[j];
-                        inputParameterList += inputParameter.Type + " " + inputParameter.Name + ", ";
+                        inputParameterList += inputParameter.Type + " " + inputParameter.Name;
+                        if (inputParameter.HasDefaultValue) {
+                            var defaultValue = ((inputParameter.Type === "String") && (inputParameter.DefaultValue !== null)) ? ('"' + inputParameter.DefaultValue + '"') : inputParameter.DefaultValue;
+                            inputParameterList += (" = " + defaultValue);
+                        }
+                        inputParameterList += ", ";
                         parameterNameList += inputParameter.Name + ", ";
                         nameValueCollectionParameterList += '{"' + inputParameter.Name + '", Configuration.Serialize(' + inputParameter.Name + ')}, ';
 

--- a/src/Nano.Demo.SelfHost.WindowsService/www/ApiExplorer/index.html
+++ b/src/Nano.Demo.SelfHost.WindowsService/www/ApiExplorer/index.html
@@ -889,7 +889,7 @@ body{font-family:"Helvetica Neue",Helvetica,Arial,sans-serif;font-size:14px;line
             '        /// <summary>Serializes the given object to a string.</summary>',
             '        public static Func<object, string> Serialize = obj =>',
             '        {',
-            '           if ( obj is string ) return obj.ToString();',
+            '           if ((obj is string) || (obj is Guid)) return obj.ToString();',
             '           if ( obj == null ) return null;',
             '           if (obj is DateTime) return Newtonsoft.Json.JsonConvert.SerializeObject(obj).Replace("\\"", "");',
             '           return Newtonsoft.Json.JsonConvert.SerializeObject( obj );',

--- a/src/Nano.Demo/Customer.cs
+++ b/src/Nano.Demo/Customer.cs
@@ -303,6 +303,23 @@ namespace Nano.Demo
         }
 
         /// <summary>
+        /// Creates a customer using a Guid.
+        /// </summary>
+        /// <param name="customerId">a guid.</param>
+        public static dynamic CreateCustomerUsingGuid(Guid customerId)
+        {
+            if (customerId == null)
+                throw new ArgumentNullException("customer");
+
+            return new
+            {
+                CustomerId = customerId,
+                FirstName = "Bob",
+                LastName = "Dole"
+            };
+        }
+
+        /// <summary>
         /// Returns the details of the files uploaded.
         /// </summary>
         /// <param name="nanoContext">The Nano context.</param>

--- a/src/Nano.Demo/Customer.cs
+++ b/src/Nano.Demo/Customer.cs
@@ -483,6 +483,45 @@ namespace Nano.Demo
         }
 
         /// <summary>
+        /// Takes an int that defaults to 16
+        /// </summary>
+        /// <param name="sixteen">defaults to 16</param>
+        public static int TakeAParameterThatHasADefaultValue(int sixteen = 16)
+        {
+            return sixteen;
+        }
+
+        /// <summary>
+        /// Takes a param with a string default
+        /// </summary>
+        /// <param name="sixteen">defaults to "sixteen"</param>
+        /// <returns></returns>
+        public static string TakeAStringThatHasADefaultValue(string sixteen = "sixteen")
+        {
+            return sixteen;
+        }
+
+        /// <summary>
+        /// Takes a param with a bool default
+        /// </summary>
+        /// <param name="notFalse">defualts to true</param>
+        /// <returns></returns>
+        public static bool TakeABoolThatHasADefaultValue(bool notFalse = true)
+        {
+            return notFalse;
+        }
+
+        /// <summary>
+        /// takes a string that defaults to null
+        /// </summary>
+        /// <param name="defaultToNull">defaults to null</param>
+        /// <returns></returns>
+        public static string TakeAStringThatHasADefaultValueOfNull(string defaultToNull = null)
+        {
+            return defaultToNull;
+        }
+
+        /// <summary>
         /// Api Response.
         /// </summary>
         /// <typeparam name="T">Response type.</typeparam>

--- a/src/Nano.Tests/ModelBinder/GetNanoMetaDataShould.cs
+++ b/src/Nano.Tests/ModelBinder/GetNanoMetaDataShould.cs
@@ -76,5 +76,90 @@ namespace Nano.Tests.ModelBinder
                 Assert.AreEqual("Tuple<Int32,String,Object>", inputParam?.Type);
             }
         }
+
+        [Test]
+        public void Return_A_Correct_Default_Int_Value()
+        {
+            using (var server = NanoTestServer.Start())
+            {
+                // Arrange
+                server.NanoConfiguration.AddMethods<Customer>();
+
+                // Act
+                var response = HttpHelper.GetResponseString(server.GetUrl() + "/metadata/GetNanoMetadata");
+                var deserializedResponse = server.NanoConfiguration.SerializationService.Deserialize<ApiMetadata>(response);
+
+                var inputParam = deserializedResponse.Operations.FirstOrDefault(x => x.Name == "TakeAParameterThatHasADefaultValue")?.InputParameters.FirstOrDefault();
+
+                Trace.WriteLine(inputParam);
+
+                // Assert
+                Assert.AreEqual(16, inputParam?.DefaultValue);
+            }
+        }
+
+        [Test]
+        public void Return_A_Correct_Default_String_Value()
+        {
+            using (var server = NanoTestServer.Start())
+            {
+                // Arrange
+                server.NanoConfiguration.AddMethods<Customer>();
+
+                // Act
+                var response = HttpHelper.GetResponseString(server.GetUrl() + "/metadata/GetNanoMetadata");
+                var deserializedResponse = server.NanoConfiguration.SerializationService.Deserialize<ApiMetadata>(response);
+
+                var inputParam = deserializedResponse.Operations.FirstOrDefault(x => x.Name == "TakeAStringThatHasADefaultValue")?.InputParameters.FirstOrDefault();
+
+                Trace.WriteLine(inputParam);
+
+                // Assert
+                Assert.AreEqual("sixteen", inputParam?.DefaultValue);
+            }
+        }
+
+        [Test]
+        public void Return_A_Correct_Default_Boolean_Value()
+        {
+            using (var server = NanoTestServer.Start())
+            {
+                // Arrange
+                server.NanoConfiguration.AddMethods<Customer>();
+
+                // Act
+                var response = HttpHelper.GetResponseString(server.GetUrl() + "/metadata/GetNanoMetadata");
+                var deserializedResponse = server.NanoConfiguration.SerializationService.Deserialize<ApiMetadata>(response);
+
+                var inputParam = deserializedResponse.Operations.FirstOrDefault(x => x.Name == "TakeABoolThatHasADefaultValue")?.InputParameters.FirstOrDefault();
+
+                Trace.WriteLine(inputParam);
+
+                // Assert
+                Assert.AreEqual(true, inputParam?.DefaultValue);
+            }
+        }
+
+        [Test]
+        public void Return_A_Correct_Default_Null_Value()
+        {
+            using (var server = NanoTestServer.Start())
+            {
+                // Arrange
+                server.NanoConfiguration.AddMethods<Customer>();
+
+                // Act
+                var response = HttpHelper.GetResponseString(server.GetUrl() + "/metadata/GetNanoMetadata");
+                var deserializedResponse = server.NanoConfiguration.SerializationService.Deserialize<ApiMetadata>(response);
+
+                var inputParam = deserializedResponse.Operations.FirstOrDefault(x => x.Name == "TakeAStringThatHasADefaultValueOfNull")?.InputParameters.FirstOrDefault();
+
+                Trace.WriteLine(inputParam);
+
+                // Assert
+                Assert.AreEqual(null, inputParam?.DefaultValue);
+                Assert.AreEqual(true, inputParam?.HasDefaultValue);
+            }
+        }
     }
 }

--- a/src/Nano.Tests/ProxyTests.cs
+++ b/src/Nano.Tests/ProxyTests.cs
@@ -81,7 +81,14 @@ namespace Nano.Tests
 				Trace.WriteLine( createDynamicCustomerResponseJson );
 				Assert.That( createDynamicCustomerResponse.FirstName == "Clark" && createDynamicCustomerResponse.LastName == "Kent" );
 				Trace.WriteLine( "" );
-			}
+
+                Trace.WriteLine("CreateCustomerUsingGuid");
+                dynamic createCustomerWithGuidResponse = ApiProxy.Customer.CreateCustomerUsingGuid(new Guid());
+                string createCustomerWithGuidResponseJson = JsonConvert.SerializeObject(createDynamicCustomerResponse);
+                Trace.WriteLine(createCustomerWithGuidResponseJson);
+                Assert.That(createCustomerWithGuidResponse.FirstName == "Bob" && createCustomerWithGuidResponse.LastName == "Dole" && createCustomerWithGuidResponse.CustomerId == Guid.Empty);
+                Trace.WriteLine("");
+            }
 		}
 	}
 
@@ -104,7 +111,7 @@ namespace Nano.Tests
             /// <summary>Serializes the given object to a string.</summary>
             public static Func<object, string> Serialize = obj =>
             {
-                if (obj is string) return obj.ToString();
+                if ((obj is string) || (obj is Guid)) return obj.ToString();
                 if (obj == null) return null;
                 if (obj is DateTime) return Newtonsoft.Json.JsonConvert.SerializeObject(obj).Replace("\"", "");
                 return Newtonsoft.Json.JsonConvert.SerializeObject(obj);
@@ -217,6 +224,14 @@ namespace Nano.Tests
             {
                 var parameters = new System.Collections.Specialized.NameValueCollection { { "customer", Configuration.Serialize(customer) } };
                 return PostJson<Object>(Configuration.BaseApiUrl + "/api/Customer/CreateDynamicCustomer", parameters, correlationId);
+            }
+
+            /// <summary>Creates a customer using a Guid.</summary>
+            /// <param name="customerId">a guid.</param>
+            public static Object CreateCustomerUsingGuid(Guid customerId, object correlationId = null)
+            {
+                var parameters = new System.Collections.Specialized.NameValueCollection { { "customerId", Configuration.Serialize(customerId) } };
+                return PostJson<Object>(Configuration.BaseApiUrl + "/api/Customer/CreateCustomerUsingGuid", parameters, correlationId);
             }
 
             /// <summary>Returns the details of the files uploaded.</summary>

--- a/src/Nano.Tests/www/ApiExplorer/index.html
+++ b/src/Nano.Tests/www/ApiExplorer/index.html
@@ -1052,7 +1052,11 @@ body{font-family:"Helvetica Neue",Helvetica,Arial,sans-serif;font-size:14px;line
 
                     for (var j = 0; j < operation.InputParameters.length; j++) {
                         var inputParameter = operation.InputParameters[j];
-                        inputParameterList += inputParameter.Type + " " + inputParameter.Name + ", ";
+                        inputParameterList += inputParameter.Type + " " + inputParameter.Name;
+                        if (inputParameter.HasDefaultValue) {
+                            var defaultValue = ((inputParameter.Type === "String") && (inputParameter.DefaultValue !== null)) ? ('"' + inputParameter.DefaultValue + '"') : inputParameter.DefaultValue;
+                            inputParameterList += (" = " + defaultValue);
+                        }
                         parameterNameList += inputParameter.Name + ", ";
                         nameValueCollectionParameterList += '{"' + inputParameter.Name + '", Configuration.Serialize(' + inputParameter.Name + ')}, ';
 

--- a/src/Nano.Tests/www/ApiExplorer/index.html
+++ b/src/Nano.Tests/www/ApiExplorer/index.html
@@ -889,7 +889,7 @@ body{font-family:"Helvetica Neue",Helvetica,Arial,sans-serif;font-size:14px;line
             '        /// <summary>Serializes the given object to a string.</summary>',
             '        public static Func<object, string> Serialize = obj =>',
             '        {',
-            '           if ( obj is string ) return obj.ToString();',
+            '           if ((obj is string) || (obj is Guid)) return obj.ToString();',
             '           if ( obj == null ) return null;',
             '           if (obj is DateTime) return Newtonsoft.Json.JsonConvert.SerializeObject(obj).Replace("\\"", "");',
             '           return Newtonsoft.Json.JsonConvert.SerializeObject( obj );',

--- a/src/Nano/Nano.cs
+++ b/src/Nano/Nano.cs
@@ -1868,6 +1868,12 @@ namespace Nano.Web.Core
 
         /// <summary>Parameter type.</summary>
         public Type Type;
+
+        /// <summary>Indicates whether the parameter has a default value.</summary>
+        public bool HasDefaultValue;
+
+        /// <summary>Default value.</summary>
+        public object DefaultValue;
     }
 
     /// <summary>Routes requests.</summary>
@@ -3255,7 +3261,7 @@ namespace Nano.Web.Core
                         if( methodParameter.Name.ToLower() == "nanocontext" || methodParameter.Type == typeof( NanoContext ) )
                             continue;
 
-                        var inputParameter = new OperationParameter { Name = methodParameter.Name, Description = methodParameter.Description, Type = GetTypeName( methodParameter.Type ), IsOptional = methodParameter.IsOptional };
+                        var inputParameter = new OperationParameter { Name = methodParameter.Name, Description = methodParameter.Description, Type = GetTypeName( methodParameter.Type ), IsOptional = methodParameter.IsOptional, HasDefaultValue = methodParameter.HasDefaultValue, DefaultValue = methodParameter.DefaultValue };
 
                         metadata.InputParameters.Add( inputParameter );
 
@@ -3546,7 +3552,7 @@ namespace Nano.Web.Core
 
                 foreach( ParameterInfo parameterInfo in methodInfo.GetParameters().OrderBy( x => x.Position ) )
                 {
-                    var methodParameter = new MethodParameter { Position = parameterInfo.Position, Name = parameterInfo.Name, Type = parameterInfo.ParameterType, IsOptional = parameterInfo.IsOptional, IsDynamic = IsDynamic( parameterInfo ), Description = xmlMethodDocumentation.GetParameterDescription( parameterInfo.Name ) };
+                    var methodParameter = new MethodParameter { Position = parameterInfo.Position, Name = parameterInfo.Name, Type = parameterInfo.ParameterType, IsOptional = parameterInfo.IsOptional, IsDynamic = IsDynamic( parameterInfo ), Description = xmlMethodDocumentation.GetParameterDescription( parameterInfo.Name ), HasDefaultValue = parameterInfo.HasDefaultValue, DefaultValue = parameterInfo.DefaultValue };
                     methodParameters.Add( methodParameter );
                 }
 
@@ -3849,6 +3855,12 @@ namespace Nano.Web.Core
 
             /// <summary>Parameter type.</summary>
             public string Type;
+
+            /// <summary>Indicates whether the parameter has a default value.</summary>
+            public bool HasDefaultValue;
+
+            /// <summary>Default value.</summary>
+            public object DefaultValue;
         }
     }
 


### PR DESCRIPTION
The C# generated proxy does not accurately translate methods parameters that have default values.
